### PR TITLE
Ignore change notify

### DIFF
--- a/influxdb.go
+++ b/influxdb.go
@@ -202,6 +202,11 @@ func (s *InfluxDBSink) decodeStat(stat StatResult) ([]ptFields, []ptTags, error)
 	return fa, ta, nil
 }
 
+// drop_stat checks the supplied fields and returns a boolean which, if true, specifies that
+// this statistic should be dropped.
+//
+// Some statistics (specifically, SMB change notify) have unusual semantics that can result in
+// misleadingly large latency values.
 func drop_stat(fields *ptFields) bool {
 	if (*fields)["op_name"] == "change_notify" || (*fields)["op_name"] == "read_directory_change" {
 		return true

--- a/influxdb.go
+++ b/influxdb.go
@@ -155,8 +155,12 @@ func (s *InfluxDBSink) decodeStat(stat StatResult) ([]ptFields, []ptTags, error)
 			default:
 				fields["value"] = vv
 			}
-			fa = append(fa, fields)
-			ta = append(ta, tags)
+			if fields["op_name"] == "change_notify" {
+				log.Debugf("Cluster %s, dropping broken change_notify stat", s.cluster)
+			} else {
+				fa = append(fa, fields)
+				ta = append(ta, tags)
+			}
 		}
 	case map[string]interface{}:
 		fields := make(ptFields)
@@ -177,8 +181,12 @@ func (s *InfluxDBSink) decodeStat(stat StatResult) ([]ptFields, []ptTags, error)
 				fields[km] = vm
 			}
 		}
-		fa = append(fa, fields)
-		ta = append(ta, tags)
+		if fields["op_name"] == "change_notify" {
+			log.Debugf("Cluster %s, dropping broken change_notify stat", s.cluster)
+		} else {
+			fa = append(fa, fields)
+			ta = append(ta, tags)
+		}
 	case nil:
 		// It seems that the stats API can return nil values where
 		// ErrorString is set, but ErrorCode is 0


### PR DESCRIPTION
Filter out the change notify SMB and IRP equivalent stats since they have strange semantics that result in misleading latency stats.