### PR TITLE
Handle missing stats properly

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Version is the released program version
-const Version = "0.06"
+const Version = "0.07"
 const userAgent = "gostats/" + Version
 
 const (
@@ -36,6 +36,7 @@ type statGroup struct {
 
 type statDetail struct {
 	//	key         string
+	valid       bool // flag if this stat doesn't exist on this cluster
 	units       string
 	datatype    string // JSON "type"
 	aggType     string // aggregation type - add enum if/when we use it
@@ -331,6 +332,10 @@ func calcBuckets(c *Cluster, mui int, sg map[string]statGroup) []statTimeSet {
 		}
 		si := c.getStatInfo(sg[group].stats)
 		for _, stat := range sg[group].stats {
+			if !si[stat].valid {
+				log.Warningf("skipping invalid stat: '%v'", stat)
+				continue
+			}
 			sui := si[stat].updateIntvl
 			var d time.Duration
 			if sui == 0 {


### PR DESCRIPTION
If stats are not found while we are parsing the stat update times,
remove them from the groups because a missing stat will cause retrieval
of all other stats in a single request to fail.
Bump version.
Drop use of io/ioutil since it is deprected since go 1.16.
Addresses #5.