### PR TITLE
Preserve Case & Backend Retries

### DIFF
--- a/example_isi_data_insights_d.toml
+++ b/example_isi_data_insights_d.toml
@@ -14,6 +14,15 @@ log_to_stdout = false
 # Default configuration uses InfluxDB (v1)
 stats_processor = "influxdb"
 
+# Maximum number of retries in case of errors during write to stat_processor
+# Default is 8 retries. Uncomment the following line to retry forever
+# stats_processor_max_retries = 0
+
+# The stats_processor_retry_interval parameter provides the ability to override the
+# minimum interval that the daemon will retry in case writing to the stats_processor fails.
+# Default is 5 second. Uncomment the following line to start with a 1 second interval.
+# stats_processor_retry_interval = 1
+
 # Maximum number of retries for http requests (both data and auth)
 # Default is 8 retries. Uncomment the following line to retry forever
 # max_retries = 0
@@ -26,6 +35,9 @@ stats_processor = "influxdb"
 # collection interval is desired/required, this value can be increased.
 # The minimum permitted (and default) stat update interval is 5 seconds
 min_update_interval_override = 5
+
+# preserve case of cluster names to lowercase, defaults to false.
+# preserve_case = true
 
 # Specifies the active list of stat groups to query, each stat group name
 # specified here should have a corresponding section in the config file.
@@ -93,6 +105,7 @@ sd_port = 9999
 # authtype = "basic-auth"
 # disabled = false
 # prometheus_port = 9090
+# preserve_case = true
 #	...
 [[cluster]]
 hostname = "demo.cluster.com"

--- a/isilon_api.go
+++ b/isilon_api.go
@@ -33,17 +33,18 @@ type AuthInfo struct {
 // cluster via the OneFS API
 type Cluster struct {
 	AuthInfo
-	AuthType    string
-	Hostname    string
-	Port        int
-	VerifySSL   bool
-	OSVersion   string
-	ClusterName string
-	baseURL     string
-	client      *http.Client
-	csrfToken   string
-	reauthTime  time.Time
-	maxRetries  int
+	AuthType     string
+	Hostname     string
+	Port         int
+	VerifySSL    bool
+	OSVersion    string
+	ClusterName  string
+	baseURL      string
+	client       *http.Client
+	csrfToken    string
+	reauthTime   time.Time
+	maxRetries   int
+	PreserveCase bool
 }
 
 // StatResult contains the information returned for a single stat key
@@ -227,7 +228,11 @@ func (c *Cluster) GetClusterConfig() error {
 	release := r["version"]
 	rel := release.(string)
 	c.OSVersion = rel
-	c.ClusterName = strings.ToLower(m["name"].(string))
+	if c.PreserveCase {
+		c.ClusterName = m["name"].(string)
+	} else {
+		c.ClusterName = strings.ToLower(m["name"].(string))
+	}
 	return nil
 }
 


### PR DESCRIPTION
Normalisation of Cluster Names is now configurable via "preserve_case" option. 
- Defaults to "false" = normalize to lower case.
- Global setting can be overwritten per individual cluster

Writing Stats to Backend Stats Sink has now configurable Retries:
- "stats_processor_max_retries" defaults to 8
- "stats_processor_retry_interval" defaults to 5 seconds
- "stats_processor_retry_interval" is the initial interval each following interval is the previous interval times 2

All settings are optional and don't break existing configs.
