### PR TITLE
rework prometheus

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require (
 	github.com/BurntSushi/toml v1.3.2
 	github.com/deckarep/golang-set/v2 v2.3.1
+	github.com/influxdata/influxdb1-client v0.0.0-20220302092344-a9ab5670611c
 	github.com/op/go-logging v0.0.0-20160315200505-970db520ece7
 	github.com/prometheus/client_golang v1.17.0
 	golang.org/x/net v0.17.0
@@ -14,7 +15,6 @@ require (
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
 	github.com/deepmap/oapi-codegen v1.12.4 // indirect
 	github.com/google/uuid v1.3.0 // indirect
-	github.com/influxdata/influxdb1-client v0.0.0-20220302092344-a9ab5670611c // indirect
 	github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 // indirect
 )
 


### PR DESCRIPTION
First, I ran `go mod tidy` to correct the influxdb1-client being shows as an indirect module instead of being shown as a direct module.

Other than that, I made some changes to the prometheus code:
* Moved the homepage content to a constant just to make it easier to read.
* Got rid of the manual creation of the json and moved to using a map and json encoding to convert it to the byte array. This should make future changes to the json structure less error-prone.
* I added a label called `instance` with the cluster name. The main reason is that the label `cluster` is frequently used when running prometheus in kubernetes to denote which kubernetes cluster prometheus is running in. Since this is used for deduplication of metrics, it overrides the `cluster` label in the metrics resulting in nothing other than the endpoint name and port to identify which isilon cluster is which. Note that the `instance` label will come across as `exported_instance`. I also left the `cluster` label for backwards compatibility. 