### PR TITLE
Force socket reuseaddr/reuseport on prom endpoints

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,6 @@ require (
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.62.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
-	golang.org/x/sys v0.31.0 // indirect
+	golang.org/x/sys v0.31.0
 	google.golang.org/protobuf v1.36.3 // indirect
 )


### PR DESCRIPTION
The Golang net/http library functions such as http.ListenAndServe() do not seem to have any ability to set the reuseaddr and reuseport options. This is a problem because if the collector is stopped and then restarted within 2*MSL, then the bind operation will fail with address/port in use. This PR adds code that uses a net.ListenConfig{} to set these options.

Fixs #21 